### PR TITLE
Add default values for message_stats

### DIFF
--- a/lib/newrelic_rabbitmq_agent.rb
+++ b/lib/newrelic_rabbitmq_agent.rb
@@ -41,12 +41,12 @@ module NewRelicRabbitMQPlugin
         report_metric "Objects/#{key.capitalize}", key, value
       end
 
-      report_metric "Messages/Publish", "Messages/Second", @messages_published.process(statistics.fetch("message_stats").fetch("publish"))
-      report_metric "Messages/Ack", "Messages/Second", @messages_acked.process(statistics.fetch("message_stats").fetch("ack"))
-      report_metric "Messages/Deliver", "Messages/Second", @messages_delivered.process(statistics.fetch("message_stats").fetch("deliver_get"))
-      report_metric "Messages/Confirm", "Messages/Second", @messages_confirmed.process(statistics.fetch("message_stats").fetch("confirm"))
-      report_metric "Messages/Redeliver", "Messages/Second", @messages_redelivered.process(statistics.fetch("message_stats").fetch("redeliver"))
-      report_metric "Messages/NoAck", "Messages/Second", @messages_noacked.process(statistics.fetch("message_stats").fetch("get_no_ack"))
+      report_metric "Messages/Publish", "Messages/Second", @messages_published.process(statistics.fetch("message_stats").fetch("publish", 0.0))
+      report_metric "Messages/Ack", "Messages/Second", @messages_acked.process(statistics.fetch("message_stats").fetch("ack", 0.0))
+      report_metric "Messages/Deliver", "Messages/Second", @messages_delivered.process(statistics.fetch("message_stats").fetch("deliver_get", 0.0))
+      report_metric "Messages/Confirm", "Messages/Second", @messages_confirmed.process(statistics.fetch("message_stats").fetch("confirm", 0.0))
+      report_metric "Messages/Redeliver", "Messages/Second", @messages_redelivered.process(statistics.fetch("message_stats").fetch("redeliver", 0.0))
+      report_metric "Messages/NoAck", "Messages/Second", @messages_noacked.process(statistics.fetch("message_stats").fetch("get_no_ack", 0.0))
 
       response = conn.get("/api/nodes")
       statistics = response.body


### PR DESCRIPTION
Fresh RabbitMQ nodes won't have filled stats until at least one message of such type passes. At some usage cases several types of messages will be missing always.

Without the default values user experiences the following error:
`ERROR: Error occurred in poll cycle: key not found: "redeliver"`
...and metric collection cycle will end without processing next values.
